### PR TITLE
TI-112 Fixed copy:config task placement for build task

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -9,7 +9,7 @@ var sequence        = require('run-sequence');
 
 // Builds your entire app once, without starting a server
 gulp.task('build', function(cb) {
-  sequence('clean', 'writeDevConfig', ['copy', 'copy:foundation', 'sass', 'uglify'], 'copy:templates', 'copy:config', cb);
+  sequence('clean', 'copy:config', 'writeDevConfig', ['copy', 'copy:foundation', 'sass', 'uglify'], 'copy:templates', cb);
 });
 
 // Copies everything in the client folder except templates, Sass, and JS


### PR DESCRIPTION
This should fix the CONFIG copy problem for
`npm run build`

`npm start` seems to be fine
