### PR TITLE
TI-137 and TI-29 allow https for view and get view to properly handle self signed certificates in the proxy

### DIFF
--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -17,10 +17,16 @@ appConfig = { //eslint-disable-line
    * localhost is used here for same computer use only.
    * You will need to put a hostname or ip address here if you want to go to
    * view this app from another machine.
+   *
+   * To use https set the https server key and certificate. And set use_https to true.
    */
   host: 'http://localhost',
   port:'8764',
-  use_https: false,
+  https: {
+    key: 'path/to/your/server.key',
+    cert: 'path/to/your/server.crt'
+  },
+  use_https: true,
 
   /**
    * The name of the realm to connect with

--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -26,11 +26,11 @@ appConfig = { //eslint-disable-line
   proxy_allow_self_signed_cert: false, // Only turn on if you have a self signed proxy in front of fusion.
 
   // Serve View via https.
-  use_https: false,
-  https: {
-    // key: 'path/to/your/server.key',
-    // cert: 'path/to/your/server.crt'
-  },
+  // use_https: true,
+  // https: {
+  //   key: 'path/to/your/server.key',
+  //   cert: 'path/to/your/server.crt'
+  // },
 
   /**
    * The name of the realm to connect with

--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -26,7 +26,7 @@ appConfig = { //eslint-disable-line
     key: 'path/to/your/server.key',
     cert: 'path/to/your/server.crt'
   },
-  use_https: true,
+  use_https: false,
 
   /**
    * The name of the realm to connect with

--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -22,11 +22,15 @@ appConfig = { //eslint-disable-line
    */
   host: 'http://localhost',
   port:'8764',
-  https: {
-    key: 'path/to/your/server.key',
-    cert: 'path/to/your/server.crt'
-  },
+
+  proxy_allow_self_signed_cert: false, // Only turn on if you have a self signed proxy in front of fusion.
+
+  // Serve View via https.
   use_https: false,
+  https: {
+    // key: 'path/to/your/server.key',
+    // cert: 'path/to/your/server.crt'
+  },
 
   /**
    * The name of the realm to connect with

--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -20,6 +20,7 @@ appConfig = { //eslint-disable-line
    */
   host: 'http://localhost',
   port:'8764',
+  use_https: false,
 
   /**
    * The name of the realm to connect with

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -21,7 +21,8 @@ gulp.task('browsersync', ['build'], function() {
 
   var browserSyncConfig = {
     baseDir: './build/',
-    middleware: middleware
+    middleware: middleware,
+    ghostMode: false
   };
 
   if(fusionConfig.use_https === true){

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -10,12 +10,20 @@ var proxyMiddleware = require('http-proxy-middleware');
 gulp.task('browsersync', ['build'], function() {
   var fusionConfig    = require('../tmp/fusion_config');
   var openPath = getOpenPath();
+
+  var proxyConfig = {
+    target: fusionConfig.host+':'+fusionConfig.port
+  };
+
+  // Allow self signed proxys to pass through with setting.
+  if(fusionConfig.proxy_allow_self_signed_cert === true) {
+    proxyConfig['secure'] = false;
+  }
+
   // build middleware.
   var middleware = [
     log(),
-    proxyMiddleware('/api', {
-      target: fusionConfig.host+':'+fusionConfig.port
-    }),
+    proxyMiddleware('/api', proxyConfig),
     historyFallback({ index: '/' + openPath + '/index.html' })
   ];
 
@@ -31,7 +39,7 @@ gulp.task('browsersync', ['build'], function() {
       browserSyncConfig['https'] = {
         key: fusionConfig.https.key,
         cert: fusionConfig.https.cert
-      }
+      };
     }
   }
 

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -19,11 +19,17 @@ gulp.task('browsersync', ['build'], function() {
     historyFallback({ index: '/' + openPath + '/index.html' })
   ];
 
+  var browserSyncConfig = {
+    baseDir: './build/',
+    middleware: middleware
+  };
+
+  if(fusionConfig.use_https === true){
+    browserSyncConfig['https'] = true;
+  }
+
   browserSync.init({
-    server: {
-      baseDir: './build/',
-      middleware: middleware
-    }
+    server: browserSyncConfig
   });
 
   // gulp.watch("app/scss/*.scss", ['sass']);

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -26,6 +26,12 @@ gulp.task('browsersync', ['build'], function() {
 
   if(fusionConfig.use_https === true){
     browserSyncConfig['https'] = true;
+    if(fusionConfig.hasOwnProperty('https') && fusionConfig.https.hasOwnProperty('key') && fusionConfig.https.hasOwnProperty('cert')){
+      browserSyncConfig['https'] = {
+        key: fusionConfig.https.key,
+        cert: fusionConfig.https.cert
+      }
+    }
   }
 
   browserSync.init({


### PR DESCRIPTION
Allows you to run View via https.

To test use a self signed cert:
instructions for creating a self signed cert:
https://devcenter.heroku.com/articles/ssl-certificate-self

in view use the new fusion config settings
```
  https: {
    key: 'path/to/your/server.key',
    cert: 'path/to/your/server.crt'
  },
  use_https: true,
```
when you restart view, you will get a page that says it is not secure, it is secure (this is default behavior for self signed cert)
click advanced and then it will let you proceed to view View

Test steps for TI-29:

1. install nginx locally.
  ```
  homebrew install nginx
  ```

2. create a file  ```/usr/local/etc/nginx/servers/fusion_proxy.conf``` with contents:
  ```
  server {
    listen      8769;
    server_name localhost;

    ssl_certificate /Users/joshuaellinger/Sites/test/server.crt;
    ssl_certificate_key /Users/joshuaellinger/Sites/test/server.key;

    ssl on;
    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
    ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
    ssl_prefer_server_ciphers on;

    location / {
      proxy_pass        http://localhost:8764;
      proxy_set_header  Host      $host;
      proxy_set_header  X-Real-IP $remote_addr;
    }
  }
  ```
where ```ssl_certificate``` and ```ssl_certificate_key``` are paths to artifacts on your machine.

3. Edit your FUSION_CONFIG to look similar.
  ```
    host: 'https://localhost',
    port:'8769',

    proxy_allow_self_signed_cert: true, // Only turn on if you have a self signed proxy in front of fusion.
  ```

4. run ```nginx``` (from anywhere) and  ```npm start``` (from the view folder)