### PR TITLE
Typeahead query profile pipeline switch fix

### DIFF
--- a/client/assets/components/searchBox/searchBoxDataService.js
+++ b/client/assets/components/searchBox/searchBoxDataService.js
@@ -19,7 +19,7 @@
 
       var queryString = QueryBuilder.objectToURLString(query);
 
-      var fullUrl = getQueryUrl(ConfigService.getIfQueryProfile()) + '?' + queryString;
+      var fullUrl = getQueryUrl(ConfigService.getIfTypeaheadQueryProfile()) + '?' + queryString;
 
       $http
         .get(fullUrl)

--- a/client/assets/js/services/ConfigService.js
+++ b/client/assets/js/services/ConfigService.js
@@ -86,6 +86,7 @@
         getTypeaheadConfig: getTypeaheadConfig,
         getTypeaheadRequestHandler: getTypeaheadRequestHandler,
         getTypeaheadField: getTypeaheadField,
+        getIfTypeaheadQueryProfile: getIfTypeaheadQueryProfile,
         getTypeaheadProfile: getTypeaheadProfile,
         getTypeaheadPipeline: getTypeaheadPipeline,
         getLandingPageRedirect: getLandingPageRedirect,
@@ -181,6 +182,10 @@
         return item.match(/^typeahead/);
       }).value();
       return _.pick(appConfig, onlyTypeAheadKeys);
+    }
+
+    function getIfTypeaheadQueryProfile() {
+      return appConfig.typeahead_use_query_profile;
     }
 
     function getTypeaheadPipeline(){


### PR DESCRIPTION
In config property `typeahead_use_query_profile` was being ignored. Fixed it.