### PR TITLE
Fix field-directive maxlength

### DIFF
--- a/client/assets/components/field/field.js
+++ b/client/assets/components/field/field.js
@@ -23,7 +23,7 @@
     };
   }
 
-  function Controller() {
+  function Controller($sanitize) {
     'ngInject';
     var fc = this;
 
@@ -36,7 +36,7 @@
     }
 
     function processField(field, highlightKey, highlight, maxlength) {
-      var result = field;
+      var result = $sanitize(_.escape(field));
       var hasHighlight = false;
 
       if (highlight && Object.keys(highlight).length > 0) {


### PR DESCRIPTION
* If the `field value` contains HTML entities they cannot be truncated to the maxlength assigned and are instead added to the page as children of the `field` span.
* The `field value` is escaped and sanitized.