### PR TITLE
Added support for clearing filters on a facet

### DIFF
--- a/client/assets/components/facetField/facetField.html
+++ b/client/assets/components/facetField/facetField.html
@@ -1,5 +1,8 @@
 <section class="accordion-item" class="block-list" ng-class="{'is-active': vm.active}">
-  <div class="accordion-title" ng-click="vm.active = !vm.active">{{vm.facetLabel ? vm.facetLabel : vm.facetName}}</div>
+  <div class="accordion-title" ng-click="vm.active = !vm.active">
+    {{vm.facetLabel ? vm.facetLabel : vm.facetName}}
+    <a ng-click="vm.clearAppliedFilters($event)">Clear all</a>
+  </div>
   <div class="accordion-content">
     <ul class="block-list">
       <li>

--- a/client/assets/components/facetField/facetField.html
+++ b/client/assets/components/facetField/facetField.html
@@ -1,7 +1,7 @@
 <section class="accordion-item" class="block-list" ng-class="{'is-active': vm.active}">
   <div class="accordion-title" ng-click="vm.active = !vm.active">
     {{vm.facetLabel ? vm.facetLabel : vm.facetName}}
-    <a ng-click="vm.clearAppliedFilters($event)">Clear all</a>
+    <span ng-click="vm.clearAppliedFilters($event)">Clear all</span>
   </div>
   <div class="accordion-content">
     <ul class="block-list">

--- a/client/assets/components/facetField/facetFieldDirective.js
+++ b/client/assets/components/facetField/facetFieldDirective.js
@@ -30,6 +30,7 @@
     vm.toggleMore = toggleMore;
     vm.getLimitAmount = getLimitAmount;
     vm.more = false;
+    vm.clearAppliedFilters = clearAppliedFilters;
     var resultsObservable = Orwell.getObservable('queryResults');
 
     activate();
@@ -243,6 +244,23 @@
       //CASE 2: query facet is a field facet with local params. The local param is present in the key of the query facet. Eg: {!tag=param}keyName
       return (val.key === key && val.transformer === 'fq:field') ||
        (val.key === ('{!tag='+vm.facetTag+'}' + key) && val.transformer === 'localParams');
+    }
+
+    /**
+     * remove all filters applied on a facet
+     * @param  {object} e event object to stopPropagation of click
+     */
+    function clearAppliedFilters(e){
+      e.stopPropagation();
+      var query = QueryService.getQueryObject();
+      if(query.hasOwnProperty('fq')){
+        var clearedFilter = _.remove(query.fq, function(value){
+          return checkQueryFacetExists(value, vm.facetName);
+        });
+        if(clearedFilter.length){
+          updateFacetQuery(query);
+        }
+      }
     }
   }
 })();

--- a/client/assets/components/facetField/facetFieldDirective.js
+++ b/client/assets/components/facetField/facetFieldDirective.js
@@ -131,7 +131,7 @@
         // Remove the key object from the query.
         // We will re-add later if we need to.
         var keyArr = _.remove(query.fq, function(value){
-          return checkQueryFacetExists(value, key);
+          return checkFacetExists(value, key);
         });
 
         // CASE: facet key exists in query.
@@ -183,7 +183,7 @@
         return false;
       }
       var keyObj = _.find(query.fq, function(val){
-        return checkQueryFacetExists(val, key);
+        return checkFacetExists(val, key);
       });
       if(_.isEmpty(keyObj)){
         return false;
@@ -239,9 +239,9 @@
      * @param  {string}  key The name of the facet
      * @return {Boolean}
      */
-    function checkQueryFacetExists(val, key){
-      //CASE 1: query facet is a field facet without local params
-      //CASE 2: query facet is a field facet with local params. The local param is present in the key of the query facet. Eg: {!tag=param}keyName
+    function checkFacetExists(val, key){
+      //CASE 1: facet is a field facet without local params
+      //CASE 2: facet is a field facet with local params. The local param is present in the key of the facet. Eg: {!tag=param}keyName
       return (val.key === key && val.transformer === 'fq:field') ||
        (val.key === ('{!tag='+vm.facetTag+'}' + key) && val.transformer === 'localParams');
     }
@@ -255,7 +255,7 @@
       var query = QueryService.getQueryObject();
       if(query.hasOwnProperty('fq')){
         var clearedFilter = _.remove(query.fq, function(value){
-          return checkQueryFacetExists(value, vm.facetName);
+          return checkFacetExists(value, vm.facetName);
         });
         if(clearedFilter.length){
           updateFacetQuery(query);

--- a/client/assets/components/facetList/facetList.scss
+++ b/client/assets/components/facetList/facetList.scss
@@ -1,0 +1,4 @@
+.facet-list div.accordion-title {
+  display: flex;
+  justify-content: space-between;
+}

--- a/client/assets/components/facetRange/facetRange.html
+++ b/client/assets/components/facetRange/facetRange.html
@@ -1,5 +1,8 @@
 <section class="accordion-item" class="block-list" ng-class="{'is-active': vm.active}">
-  <div class="accordion-title" ng-click="vm.active = !vm.active">{{vm.facetLabel ? vm.facetLabel : vm.facetName}}</div>
+  <div class="accordion-title" ng-click="vm.active = !vm.active">
+    {{vm.facetLabel ? vm.facetLabel : vm.facetName}}
+    <span ng-click="vm.clearAppliedFilters($event)">Clear all</span>
+  </div>
   <div class="accordion-content">
     <ul class="block-list">
       <li>

--- a/client/assets/components/facetRange/facetRangeDirective.js
+++ b/client/assets/components/facetRange/facetRangeDirective.js
@@ -30,6 +30,7 @@
     vm.toggleMore = toggleMore;
     vm.getLimitAmount = getLimitAmount;
     vm.more = false;
+    vm.clearAppliedFilters = clearAppliedFilters;
     var resultsObservable = Orwell.getObservable('queryResults');
     vm.facetCounts = [];
 
@@ -266,6 +267,21 @@
           transformer: 'TO'
         }
       ];
+    }
+
+    /**
+     * remove all filters applied on a facet
+     * @param  {object} e event object to stopPropagation of click
+     */
+    function clearAppliedFilters(e){
+      e.stopPropagation();
+      var query = QueryService.getQueryObject();
+      if(query.hasOwnProperty('fq')){
+        var clearedFilter = _.remove(query.fq, {key: vm.facetName, transformer: 'fq:range'});
+        if(clearedFilter.length){
+          updateFacetQuery(query);
+        }
+      }
     }
   }
 })();


### PR DESCRIPTION
* All filters applied on a certain facet can be cleared by clicking `Clear all`.
* Present in the facet header.
* Supported in field and range facets. Currently checks only the facet name and transformer type
* Renamed checkQueryFacetExists to checkFacetExists