### PR TITLE
Doc for Jetty webapp configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,5 @@ Also see [README.md](../README.md) for instructions on installing and running Lu
   How to customize the templates that control how View displays different document types in search results.
 
 * [How to Use QueryBuilder](HowToUseQueryBuilder.md)
+
+* [How to deploy View as a webapp in Jetty](ViewAsJettyWebapp.md)

--- a/docs/ViewAsJettyWebapp.md
+++ b/docs/ViewAsJettyWebapp.md
@@ -1,0 +1,11 @@
+# How to deploy View as a webapp in Jetty
+
+  1. View first needs to be built either by running `./view.sh start` in a downloaded package or by running `npm start` in the cloned repository. This will compile the SaSS and assemble your Angular app and it will be located in `app/build`.
+
+  2. Copy `app/build` into the webapps folder in Jetty `webapps/<foldername>`.
+
+  3. Add `<base href="/<foldername>/"></base>` to the `<head></head>` section in `webapps/<foldername>/index.html`.
+
+  4. View is now accessible at `http://<jetty IP>:<jetty port>/<foldername>`!
+
+  Once you have logged into View, you will be redirected to `http://<jetty IP>:<jetty port>/<foldername>/search?query=<configured default query>`. Please note that refreshing the app will return a **404**, unless the routing has been configured in Jetty.


### PR DESCRIPTION
- Added a doc to `/docs/` to explain basic configuration of a View webapp in Jetty
