### PR TITLE
Performance improvements for production build

### DIFF
--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -21,7 +21,7 @@ appConfig = { //eslint-disable-line
    * To use https set the https server key and certificate. And set use_https to true.
    */
   host: 'http://localhost',
-  port:'8764',
+  port: '8764',
 
   proxy_allow_self_signed_cert: false, // Only turn on if you have a self signed proxy in front of fusion.
 

--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -25,6 +25,9 @@ appConfig = { //eslint-disable-line
 
   proxy_allow_self_signed_cert: false, // Only turn on if you have a self signed proxy in front of fusion.
 
+  // The port from which View will be served. defaults to 3000.
+  server_port: 3000,
+
   // Serve View via https.
   // use_https: true,
   // https: {

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ To run the compiling process once, without watching any files, use the `build` c
 ```bash
 npm run build
 ```
+this command creates a built and 'productionized' version of view which can be copied from the build folder to another folder/machine and served on your own webserver.
+
+Alternatively for deployment, you can use the command
+```bash
+npm run start-production
+```
+
+this command runs a node server, with minimized packages, and works similarly to  the `npm start` command.
 
 ## Unit testing
 

--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -1,8 +1,6 @@
 ---
 name: home
 url: /search?query
-animationIn: slideInRight
-animationOut: slideOutLeft
 controller: HomeController as hc
 ---
 <zf-offcanvas position="left"></zf-offcanvas>

--- a/client/templates/login.html
+++ b/client/templates/login.html
@@ -1,8 +1,6 @@
 ---
 name: login
 url: /login
-animationIn: slideInLeft
-animationOut: slideOutRight
 controller: LoginController as vm
 ---
 <div class="grid-frame vertical">

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -73,10 +73,10 @@ gulp.task('uglify:app', function() {
     sourcemapsWrite = $.if(!global.isProduction, $.sourcemaps.write('.'));
 
   return gulp.src(global.paths.appJS, { base: 'client' })
-    .pipe(sourcemapsInit)
-    .pipe(uglify)
     .pipe($.plumber())
+    .pipe(sourcemapsInit)
     .pipe($.ngAnnotate())
+    .pipe(uglify)
     .pipe($.directiveReplace({root: 'client'}))
     .pipe($.concat('app.js'))
     .pipe(sourcemapsWrite)

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -42,10 +42,16 @@ gulp.task('browsersync', ['build'], function() {
     }
   }
 
+  var serverPort = 3000;
+  if(fusionConfig.server_port && fusionConfig.server_port !== false){
+    serverPort = fusionConfig.server_port;
+  }
+
   browserSync.init({
     server: browserSyncConfig,
     ghostMode: false,
-    ui: false
+    ui: false,
+    port: serverPort
   });
 
   // gulp.watch("app/scss/*.scss", ['sass']);

--- a/gulp/serve.js
+++ b/gulp/serve.js
@@ -44,7 +44,8 @@ gulp.task('browsersync', ['build'], function() {
 
   browserSync.init({
     server: browserSyncConfig,
-    ghostMode: false
+    ghostMode: false,
+    ui: false
   });
 
   // gulp.watch("app/scss/*.scss", ['sass']);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "changelog": "https://github.com/lucidworks/lucidworks-view/blob/master/CHANGELOG.md",
   "homepage": "https://lucidworks.com/products/view",
   "scripts": {
+    "start-production": "./node_modules/gulp/bin/gulp.js --production",
     "start": "./node_modules/gulp/bin/gulp.js",
     "build": "./node_modules/gulp/bin/gulp.js build --production",
     "test": "./node_modules/karma/bin/karma start karma.conf.js"


### PR DESCRIPTION
Performance improvement for production build

* Now `npm run start-production` will serve with minified production app. The JS loaded size is reduced from 2.4mb to 500k. (2.2mb => 400k for foundation.js, and 100k => 59k for app.js )
* Fix an issue to make sure ngAnnotate routine is invoked before the JS get uglified which building production.

* Remove anmiation while page loading, which will cause considerable performance impact especially on slow browser.

- [x] ~~Will double check to see if animation for routing transition is required.~~
- [x] Update Docs for newly added `build-production` script.