### PR TITLE
Change performant build to be default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ To run the compiling process once, without watching any files, use the `build` c
 ```bash
 npm run build
 ```
-this command creates a built and 'productionized' version of View which can be copied from the build folder to another folder/machine and served on your own webserver.
+this command creates a built version of View which can be copied from the build folder to another folder/machine and served on your own webserver.
 
-Alternatively for deployment, you can use the command
+For development purposes, you can develop without a minified build by using the command
 ```bash
-npm run start-production
+npm run start-dev
 ```
 
 this command runs a node server, with minimized packages, and works similarly to  the `npm start` command.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "changelog": "https://github.com/lucidworks/lucidworks-view/blob/master/CHANGELOG.md",
   "homepage": "https://lucidworks.com/products/view",
   "scripts": {
-    "start-production": "./node_modules/gulp/bin/gulp.js --production",
-    "start": "./node_modules/gulp/bin/gulp.js",
+    "start": "./node_modules/gulp/bin/gulp.js --production",
+    "start-dev": "./node_modules/gulp/bin/gulp.js",
     "build": "./node_modules/gulp/bin/gulp.js build --production",
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },

--- a/win64/view.cmd
+++ b/win64/view.cmd
@@ -7,4 +7,4 @@ echo Checking node js version:
 set thecmd=%1
 if [%1]==[] set thecmd=start
 
-%NODEJS_EXE% %~dp0node_modules\gulp\bin\gulp.js
+%NODEJS_EXE% %~dp0node_modules\gulp\bin\gulp.js --production


### PR DESCRIPTION
now minified version is default and and there is a dev command, so we needed to change the documentation