### PR TITLE
TI-226 Fix url encoding of links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ FUSION_CONFIG.*.js
 !FUSION_CONFIG.sample.js
 .jira-prefix
 .project
+.vscode
 installer/Output

--- a/client/assets/components/document/document_EXAMPLE/document_EXAMPLE.js
+++ b/client/assets/components/document/document_EXAMPLE/document_EXAMPLE.js
@@ -30,7 +30,13 @@
     activate();
 
     function activate() {
+      vm.doc = processDocument(vm.doc);
       vm.postSignal = SignalsService.postClickSignal;
+    }
+
+    function processDocument(doc) {
+      doc._lw_id_decoded = doc.id ? decodeURIComponent(doc.id) : doc.id;
+      return doc;
     }
   }
 })();

--- a/client/assets/components/document/document_default/document_default.js
+++ b/client/assets/components/document/document_default/document_default.js
@@ -62,7 +62,7 @@
 
       doc.lw_image = getField('image', doc);
 
-      doc.lw_url = getField('head_url', doc);
+      doc.lw_url = decodeURIComponent(getField('head_url', doc));
 
       doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(doc);
       doc.position = vm.position;

--- a/client/assets/components/document/document_jira/contentTypes/jiraIssue.html
+++ b/client/assets/components/document/document_jira/contentTypes/jiraIssue.html
@@ -1,7 +1,7 @@
 <div class="detail jira-issue vertical grid-content">
 
   <h3 class="subheader">
-    <a ng-href="{{::vm.doc.id}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.id}})" rel="noopener" target="_blank">
+    <a ng-href="{{::vm.doc._lw_id_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_id_decoded}})" rel="noopener" target="_blank">
       <field value="::vm.doc.summary_s" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="summary_s"></field>
     </a>
   </h3>
@@ -17,7 +17,7 @@
              hkey="jira_content_type_s"></field>
       </div>
       <div class="key" ng-if="::vm.doc.parent_s">
-        <a ng-href="{{::vm.doc.id}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.id}})" rel="noopener" target="_blank">
+        <a ng-href="{{::vm.doc._lw_id_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_id_decoded}})" rel="noopener" target="_blank">
           <field value="::vm.doc.key_s" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="key_s"></field>
         </a>
       </div>

--- a/client/assets/components/document/document_jira/contentTypes/jiraIssue.js
+++ b/client/assets/components/document/document_jira/contentTypes/jiraIssue.js
@@ -32,8 +32,14 @@
 
     function activate() {
       vm.postSignal = postSignal;
-      vm.doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(vm.doc);
-      vm.doc.page = PaginateService.getNormalizedCurrentPage();
+      vm.doc = processDocument(vm.doc);
+    }
+
+    function processDocument(doc) {
+      doc._lw_id_decoded = doc.id ? decodeURIComponent(doc.id) : doc.id;
+      doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(vm.doc);
+      doc.page = PaginateService.getNormalizedCurrentPage();
+      return doc;
     }
 
     function postSignal(options){

--- a/client/assets/components/document/document_jira/contentTypes/jiraProject.html
+++ b/client/assets/components/document/document_jira/contentTypes/jiraProject.html
@@ -1,7 +1,7 @@
 <div class="detail jira-issue vertical grid-content">
   <h3 class="subheader">
 
-    <a ng-href="{{::vm.doc.id}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.id}})" rel="noopener" target="_blank">
+    <a ng-href="{{::vm.doc._lw_id_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_id_decoded}})" rel="noopener" target="_blank">
       <field value="::vm.doc.name_s" highlight="vm.highlight[doc.id]" maxlength="200" hkey="name_s"></field>
     </a>
   </h3>
@@ -17,7 +17,7 @@
              hkey="jira_content_type_s"></field>
       </div>
       <div class="key" ng-if="::vm.doc.parent_s">
-        <a ng-href="{{::vm.doc.id}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.id}})" rel="noopener" target="_blank">
+        <a ng-href="{{::vm.doc._lw_id_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_id_decoded}})" rel="noopener" target="_blank">
           <field value="::vm.doc.key_s" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="key_s"></field>
         </a>
       </div>

--- a/client/assets/components/document/document_jira/contentTypes/jiraProject.js
+++ b/client/assets/components/document/document_jira/contentTypes/jiraProject.js
@@ -36,6 +36,7 @@
     }
 
     function processDocument(doc) {
+      doc._lw_id_decoded = doc.id ? decodeURIComponent(doc.id) : doc.id;
       doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(doc);
       doc.page = PaginateService.getNormalizedCurrentPage();
       return doc;

--- a/client/assets/components/document/document_slack/document_slack.html
+++ b/client/assets/components/document/document_slack/document_slack.html
@@ -14,7 +14,7 @@
         @<field value="::vm.doc.user_s" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="user_s"></field>
         </div>
         <div class="timestamp" ng-if="::vm.doc.timestamp_tdt">
-          <a ng-href="{{::vm.doc.id}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.id}})" rel="noopener" target="_blank">
+          <a ng-href="{{::vm.doc._lw_id_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_id_decoded}})" rel="noopener" target="_blank">
             <field value="::vm.doc.timestamp_tdtFormatted"></field> UTC
           </a>
         </div>

--- a/client/assets/components/document/document_slack/document_slack.js
+++ b/client/assets/components/document/document_slack/document_slack.js
@@ -39,7 +39,8 @@
     function processDocument(doc) {
       doc.timestamp_tdtFormatted = $filter('date')(vm.doc.timestamp_tdt, 'M/d/yy h:mm:ss a');
       // For multivalued fields
-      doc.text = _.isArray(doc.text)?_.join(doc.text,' '):doc.text;
+      doc.text = _.isArray(doc.text) ? _.join(doc.text, ' ') : doc.text;
+      doc._lw_id_decoded = doc.id ? decodeURIComponent(doc.id) : doc.id;
       doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(doc);
       doc.position = vm.position;
       doc.page = PaginateService.getNormalizedCurrentPage();

--- a/client/assets/components/document/document_web/document_web.html
+++ b/client/assets/components/document/document_web/document_web.html
@@ -2,18 +2,18 @@
   <div class="detail vertical grid-content" >
     <!-- show head field linked with a title. -->
     <h3 class="head-field" ng-if="::vm.doc.title">
-      <a ng-href="{{vm.doc.url[0]}}" ng-click="::vm.postSignal({params: {lw_url: vm.doc.url[0]}})" rel="noopener" target="_blank">
+      <a ng-href="{{vm.doc._lw_url_decoded}}" ng-click="::vm.postSignal({params: {lw_url: vm.doc._lw_url_decoded}})" rel="noopener" target="_blank">
         <field value="::vm.doc.title" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="title"></field>
       </a>
     </h3>
     <!-- show head field without a title. -->
     <h3 class="head-field" ng-if="::(!vm.doc.title && !!vm.doc.url)">
-      <a ng-href="{{::vm.doc.url[0]}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.url[0]}})" rel="noopener" target="_blank">
+      <a ng-href="{{::vm.doc._lw_url_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_url_decoded}})" rel="noopener" target="_blank">
         <field value="::vm.doc.url" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="url"></field>
       </a>
     </h3>
     <h3 class="subheader" ng-if="::(!vm.doc.title && !vm.doc.url)">
-      <a ng-href="{{::vm.doc.id}}" ng-click="vm.postSignal({params: {lw_url: vm.doc.id}})" rel="noopener" target="_blank">
+      <a ng-href="{{::vm.doc._lw_id_decoded}}" ng-click="vm.postSignal({params: {lw_url: vm.doc._lw_id_decoded}})" rel="noopener" target="_blank">
         <field value="::vm.doc.id" highlight="::vm.highlight[doc.id]" khey="id" maxlength="200"></field>
       </a>
     </h3>

--- a/client/assets/components/document/document_web/document_web.js
+++ b/client/assets/components/document/document_web/document_web.js
@@ -33,9 +33,16 @@
 
     function activate() {
       vm.postSignal = postSignal;
-      vm.doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(vm.doc);
-      vm.doc.position = vm.position;
-      vm.doc.page = PaginateService.getNormalizedCurrentPage();
+      vm.doc = processDocument(vm.doc);
+    }
+
+    function processDocument(doc) {
+      doc._lw_id_decoded = doc.id ? decodeURIComponent(doc.id) : doc.id;
+      doc._lw_url_decoded = _.has(doc, 'url[0]') ? decodeURIComponent(doc.url) : doc.url;
+      doc.__signals_doc_id__ = SignalsService.getSignalsDocumentId(vm.doc);
+      doc.position = vm.position;
+      doc.page = PaginateService.getNormalizedCurrentPage();
+      return doc;
     }
 
     function postSignal(options){

--- a/client/assets/js/services/QueryDataService.js
+++ b/client/assets/js/services/QueryDataService.js
@@ -59,7 +59,7 @@
           queryResultsObservable.setContent({
             numFound: 0
           });
-          deferred.reject(err.data);
+          deferred.reject(err);
         }
 
         return deferred.promise;


### PR DESCRIPTION
# Tl;dr
Link URLs are not decoded.

# Details
<!-- As much detail as you think is necessary -->

# How to verify
1. Crawl a link in a fusion web crawl that has ampersands in the url.
    Ex: ```https://play.google.com/store/apps/details?id=com.sololearn.php&hl=en```
2. Try to click through that link.

Expected outcome:
link works as expected

Actual outcome:
has &amp; instead of ? in the url, so url is wrong