### PR TITLE
add-eslintrc-in-package

### DIFF
--- a/gulp/package.js
+++ b/gulp/package.js
@@ -25,7 +25,7 @@ var fileLocations = {
   win64: ['win64/**/*'],
   main_components: [
     '.bowerrc',
-    '.eslintrc',
+    '.eslintrc.js',
     '.gitignore',
     '.sass-lint.yml',
     'bower.json',


### PR DESCRIPTION
# Details
* Refer to `.eslintrc.js` correctly in the main_components object in `gulp/package.js`.

# How to Verify 
* `gulp cook`
* `gulp package`
* copy the package to another directory in a clean env.
* untar the package. `cd app`.
* `./view.sh start`. There should not be any errors.