### PR TITLE
TI-225 Keep URL after login after a redirect

### DIFF
--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -201,6 +201,12 @@ appConfig = { //eslint-disable-line
   // @see https://lucidworks.com/blog/2016/02/04/fusion-plus-solr-suggesters-search-less-typing/
 
   //typeahead_requesthandler: 'suggest', // recommended (requires configuration)
-  typeahead_requesthandler: 'select'
+  typeahead_requesthandler: 'select',
 
+  /**
+   * Default query
+   *
+   * If there is no query provided in the URL this query will be used. It is in object form.
+   */
+  default_query: {q:'*'}
 };

--- a/bower.json
+++ b/bower.json
@@ -28,12 +28,14 @@
     "angular-sanitize": "~1.4.10",
     "angular-rison": "~0.0.13",
     "angularjs-humanize": "master",
-    "angular-mass-autocomplete": "^0.5.0"
+    "angular-mass-autocomplete": "^0.5.0",
+    "angular-ui-router": "~0.4.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.10"
   },
   "resolutions": {
-    "angular": "1.3.x - 1.4.x"
+    "angular": "1.3.x - 1.4.x",
+    "angular-ui-router": "^0.4.2"
   }
 }

--- a/client/assets/components/document/document_default/document_default.js
+++ b/client/assets/components/document/document_default/document_default.js
@@ -72,7 +72,6 @@
         key: getTemplateDisplayFieldName(ConfigService.getFields.get('description')),
         value: getField('description', doc)
       };
-      debugger;
 
       doc.lw_image = {
         key: getTemplateDisplayFieldName(ConfigService.getFields.get('image')),

--- a/client/assets/components/documentList/documentList.js
+++ b/client/assets/components/documentList/documentList.js
@@ -102,7 +102,7 @@
             }
             else{
               vm.showGroupedResults['noGroupedValue'] = true;
-            };
+            }
           });
         }
         else{

--- a/client/assets/components/facetField/facetFieldDirective.js
+++ b/client/assets/components/facetField/facetFieldDirective.js
@@ -22,7 +22,7 @@
     };
   }
 
-  function Controller(ConfigService, QueryService, URLService, QueryDataService, Orwell, FoundationApi, $filter, $log) {
+  function Controller(ConfigService, QueryService, QueryDataService, Orwell, FoundationApi, $filter, $log) {
     'ngInject';
     var vm = this;
     vm.facetCounts = [];
@@ -168,7 +168,7 @@
      */
     function updateFacetQuery(query){
       query.start = 0;
-      URLService.setQuery(query);
+      QueryService.setQuery(query);
     }
 
     /**

--- a/client/assets/components/facetRange/facetRangeDirective.js
+++ b/client/assets/components/facetRange/facetRangeDirective.js
@@ -23,7 +23,7 @@
     };
   }
 
-  function Controller(ConfigService, FacetRangeService, QueryService, QueryDataService, Orwell, FoundationApi, URLService) {
+  function Controller(ConfigService, FacetRangeService, QueryService, Orwell, FoundationApi) {
     'ngInject';
     var vm = this;
     vm.facetCounts = [];
@@ -155,7 +155,7 @@
      */
     function updateFacetQuery(query) {
       query.start = 0;
-      URLService.setQuery(query);
+      QueryService.setQuery(query);
     }
 
     /**

--- a/client/assets/components/login/login.js
+++ b/client/assets/components/login/login.js
@@ -5,6 +5,7 @@
     .module('lucidworksView.components.login', ['lucidworksView.services.auth',
       'ui.router'
     ])
+    .constant('QUERY_PARAM', 'query')
     .directive('login', login);
 
   function login() {
@@ -19,7 +20,7 @@
 
   }
 
-  function Controller(ConfigService, Orwell, AuthService, $state, $stateParams) {
+  function Controller(ConfigService, Orwell, AuthService, $state, QUERY_PARAM) {
     'ngInject';
     var vm = this;
     vm.username = '';
@@ -39,8 +40,8 @@
       function success() {
         vm.submitting = false;
         var params = {};
-        if ($stateParams.previousUrl) {
-          params = {query:$stateParams.previousUrl};
+        if ($state.params[QUERY_PARAM]) {
+          params[QUERY_PARAM] = $state.params[QUERY_PARAM];
         }
         $state.go('home', params);
       }

--- a/client/assets/components/login/login.js
+++ b/client/assets/components/login/login.js
@@ -19,7 +19,7 @@
 
   }
 
-  function Controller(ConfigService, Orwell, AuthService, $state) {
+  function Controller(ConfigService, Orwell, AuthService, $state, $stateParams) {
     'ngInject';
     var vm = this;
     vm.username = '';
@@ -38,7 +38,11 @@
 
       function success() {
         vm.submitting = false;
-        $state.go('home');
+        var params = {};
+        if ($stateParams.previousUrl) {
+          params = {query:$stateParams.previousUrl};
+        }
+        $state.go('home', params);
       }
 
       function failure(err) {

--- a/client/assets/components/paginate/paginateDirective.js
+++ b/client/assets/components/paginate/paginateDirective.js
@@ -20,7 +20,7 @@
 
   }
 
-  function Controller(Orwell, PaginateService, URLService, $filter) {
+  function Controller(Orwell, PaginateService, QueryService, $filter) {
     'ngInject';
     var vm = this;
     vm.page = 0;
@@ -102,7 +102,7 @@
       if (page > PaginateService.getTotalPages()) return;
       if (page === PaginateService.getCurrentPage()) return;
       // This will change the query and cause the interface to make an http call.
-      URLService.setQuery({
+      QueryService.setQuery({
         start: PaginateService.pageToStartRow(page)
       });
     }

--- a/client/assets/components/sort/sort.js
+++ b/client/assets/components/sort/sort.js
@@ -21,7 +21,7 @@
 
   }
 
-  function Controller($scope, ConfigService, QueryService, URLService) {
+  function Controller($scope, ConfigService, QueryService) {
     'ngInject';
     var vm = this;
     vm.switchSort = switchSort;
@@ -58,12 +58,12 @@
       case 'text':
         if(angular.isUndefined(query.sort)){
           query.sort = sort.label+'%20'+sort.order;
-          URLService.setQuery(query);
+          QueryService.setQuery(query);
         }
         break;
       default:
         delete query.sort;
-        URLService.setQuery(query);
+        QueryService.setQuery(query);
       }
     }
   }

--- a/client/assets/js/controllers/HomeController.js
+++ b/client/assets/js/controllers/HomeController.js
@@ -13,7 +13,7 @@
     var query;
     var sorting;
 
-    hc.searchQuery = '*';
+    hc.searchQuery = ConfigService.config.default_query.q;
 
     activate();
 
@@ -35,7 +35,7 @@
 
       query = URLService.getQueryFromUrl();
       //Setting the query object... also populating the the view model
-      hc.searchQuery = _.get(query,'q','*');
+      hc.searchQuery = _.get(query,'q',ConfigService.config.default_query.q);
       // Use an observable to get the contents of a queryResults after it is updated.
       resultsObservable = Orwell.getObservable('queryResults');
       resultsObservable.addObserver(function(data) {
@@ -55,7 +55,7 @@
       // than the digest cycle of the initial load-rendering
       // The $timeout is needed or else the query to fusion is not made.
       $timeout(function(){
-        URLService.setQuery(query);
+        QueryService.setQuery(query);
       });
     }
 
@@ -131,7 +131,7 @@
         fq: []
       };
 
-      URLService.setQuery(query);
+      QueryService.setQuery(query);
     }
 
     /**
@@ -156,11 +156,11 @@
       switch(sort.type) {
       case 'text':
         query.sort = sort.label+' '+sort.order;
-        URLService.setQuery(query);
+        QueryService.setQuery(query);
         break;
       default:
         delete query.sort;
-        URLService.setQuery(query);
+        QueryService.setQuery(query);
       }
     }
 

--- a/client/assets/js/services/AuthInterceptor.js
+++ b/client/assets/js/services/AuthInterceptor.js
@@ -40,7 +40,7 @@
               //CASE: If anonymous login failed, then go to login
               else{
                 $log.info('Failed to create anonymous session');
-                $state.go('login',prepareQueryForRedirect());
+                $state.go('login', prepareQueryForRedirect());
               }
               deferred.reject(err);
             });

--- a/client/assets/js/services/AuthInterceptor.js
+++ b/client/assets/js/services/AuthInterceptor.js
@@ -6,7 +6,7 @@
     .factory('AuthInterceptor', AuthInterceptor);
 
 
-  function AuthInterceptor($q, $log, $rootScope, $injector) {
+  function AuthInterceptor($location, $q, $log, $rootScope, $injector) {
     'ngInject';
     var tryingAnon = false;
     return {
@@ -16,6 +16,7 @@
     function responseError(resp) {
       var deferred = $q.defer();
       var $state = $injector.get('$state');
+      var flatQuery = $location.search()['query'] || '(q:\'*\')';
       // CASE: If the app is on login page, the code is 401 and the request wasn't a api/session POST, then only attempt anon login
       // The reason for this check so that not all the response errors are intercepted
       if (!$state.is('login') && (resp.status === 401) && !isLoginRequest(resp.config)) {
@@ -28,19 +29,19 @@
               //CASE: If anonymous session creation is successful, go home
               $log.info('Created anonymous session');
               deferred.reject();
-              $state.go('home',{query:'(q:\'*\')'});
+              $state.go('home',{query:flatQuery});
             },function(err){
               // TODO: Investigate why 201 is going to error handler...
               // If it's the expected behaviour, figure out a better solution
               //CASE: If anonymous login succeeded with a 201 response, go to `home`
               if(err.status === 201){
                 $log.info('Created anonymous session');
-                $state.go('home',{query:'(q:\'*\')'});
+                $state.go('home',{query:flatQuery});
               }
               //CASE: If anonymous login failed, then go to login
               else{
                 $log.info('Failed to create anonymous session');
-                $state.go('login');
+                $state.go('login',{previousUrl:flatQuery});
               }
               deferred.reject(err);
             });

--- a/client/assets/js/services/ConfigService.js
+++ b/client/assets/js/services/ConfigService.js
@@ -39,10 +39,17 @@
       typeahead_query_profile_id: 'default',
       typeahead_fields: ['id'],
       typeahead_requesthandler: 'select',
-      landing_page_redirect: true
+      landing_page_redirect: true,
+      default_query: {q:'*'}
     })
     /** Config overrides from FUSION_CONFIG.js **/
     .constant('CONFIG_OVERRIDE', window.appConfig) //eslint-disable-line
+    .constant('QUERY_OBJECT_INTERNAL_DEFAULT', {
+      q: '*',
+      start: 0,
+      // Do not override the return of JSON
+      wt: 'json'
+    })
 
     .provider('ConfigService', ConfigService);
 
@@ -53,7 +60,7 @@
    * @param {object} CONFIG_DEFAULT  [description]
    * @param {object} CONFIG_OVERRIDE [description]
    */
-  function ConfigService(CONFIG_DEFAULT, CONFIG_OVERRIDE) {
+  function ConfigService(CONFIG_DEFAULT, CONFIG_OVERRIDE, QUERY_OBJECT_INTERNAL_DEFAULT) {
     'ngInject';
     var appConfig,
       vm = this;
@@ -105,6 +112,7 @@
       var localOverride = (arguments.length > 0) ? arguments[0] : {};
 
       appConfig = _.assign({}, CONFIG_DEFAULT, CONFIG_OVERRIDE, localOverride);
+      initQueryDefault(appConfig);
       vm.config = appConfig;
     }
 
@@ -210,6 +218,9 @@
 
     function getFieldLabels() {
       return appConfig.field_display_labels;
+    }
+    function initQueryDefault() {
+      appConfig.default_query = _.assign({}, QUERY_OBJECT_INTERNAL_DEFAULT, appConfig.default_query);
     }
   }
 })();

--- a/client/assets/js/services/ConfigService.js
+++ b/client/assets/js/services/ConfigService.js
@@ -112,7 +112,7 @@
       var localOverride = (arguments.length > 0) ? arguments[0] : {};
 
       appConfig = _.assign({}, CONFIG_DEFAULT, CONFIG_OVERRIDE, localOverride);
-      initQueryDefault(appConfig);
+      initQueryDefault();
       vm.config = appConfig;
     }
 

--- a/client/assets/js/services/LocalParamService.js
+++ b/client/assets/js/services/LocalParamService.js
@@ -45,7 +45,7 @@
     }
 
     function localParamWrapperTransformer(data) {
-      return JSON.stringify(data);
+      return angular.toJson(data);
     }
   }
 

--- a/client/assets/js/services/QueryService.js
+++ b/client/assets/js/services/QueryService.js
@@ -45,13 +45,16 @@
         return queryObservable.getContent();
       }
 
+      /**
+       * Sets the query and sets off a new search via observable;
+       */
       function setQuery(query) {
         if (ConfigService.config.query_debug) {
           $log.debug('query', query);
         }
         queryObject = _.assign({}, queryObject, query, {rows: ConfigService.config.docs_per_page});
         queryObservable.setContent(queryObject);
-        URLService.setQuery(queryObject);
+        URLService.setQueryToURLAndGo(queryObject);
       }
 
     }

--- a/client/assets/js/services/QueryService.js
+++ b/client/assets/js/services/QueryService.js
@@ -3,12 +3,6 @@
       'lucidworksView.services.queryData'
     ])
     .config(Config)
-    .constant('QUERY_OBJECT_DEFAULT', {
-      q: '*',
-      start: 0,
-      // Do not override the return of JSON
-      wt: 'json'
-    })
     .provider('QueryService', QueryService);
 
   function Config(OrwellProvider) {
@@ -22,16 +16,15 @@
 
     /////////////
 
-    function $get($log, ConfigService, Orwell, QUERY_OBJECT_DEFAULT, QueryDataService) {
+    function $get($log, ConfigService, Orwell, QueryDataService, URLService) {
       'ngInject';
       var queryObservable = Orwell.getObservable('query'),
-        queryObject = QUERY_OBJECT_DEFAULT;
+        queryObject = ConfigService.config.default_query;
 
       activate();
 
       queryObservable.addObserver(function (query) {
         QueryDataService.getQueryResults(query);
-
       });
 
       return {
@@ -41,7 +34,7 @@
       };
 
       function activate() {
-        queryObservable.setContent(queryObject);
+        queryObservable.setContent(ConfigService.config.default_query);
       }
 
       function getQueryObservable() {
@@ -58,7 +51,7 @@
         }
         queryObject = _.assign({}, queryObject, query, {rows: ConfigService.config.docs_per_page});
         queryObservable.setContent(queryObject);
-
+        URLService.setQuery(queryObject);
       }
 
     }

--- a/client/assets/js/services/URLService.js
+++ b/client/assets/js/services/URLService.js
@@ -19,10 +19,21 @@
     return {
       setQueryToURLAndGo: setQueryToURLAndGo,
       convertQueryToStateObject: convertQueryToStateObject,
-      getQueryFromUrl: getQueryFromUrl
+      getQueryFromUrl: getQueryFromUrl,
+
+      /// deprecated
+      setQuery:setQuery
     };
 
     //////////
+
+    /**
+     * setQuery
+     * DEPRECATED in 1.4 use QueryService.setQuery() instead
+     **/
+    function setQuery() {
+      $log.error('The function URLService.setQuery() was deprecated in Lucidworks View 1.4 use QueryService.setQuery() instead.');
+    }
 
     /**
      * Sets the URL bar

--- a/client/assets/js/services/URLService.js
+++ b/client/assets/js/services/URLService.js
@@ -9,10 +9,11 @@
 
   var blankQuery = {
     q: '*',
-    start: 0
+    start: 0,
+    wt: 'json'
   };
 
-  function URLService($log, $rison, $state, $location, QueryService, BLANK_QUERY,
+  function URLService($log, $rison, $state, $location, BLANK_QUERY,
     QUERY_PARAM) {
     'ngInject';
     return {
@@ -30,8 +31,7 @@
      * @param {object} queryObject The query object
      */
     function setQuery(queryObject) {
-      QueryService.setQuery(queryObject);
-      var queryObjectToBeStringed = _.clone(QueryService.getQueryObject(),true);
+      var queryObjectToBeStringed = _.clone(queryObject,true);
       //Only need the slashes to get encoded, so that app state doesn't change
       queryObjectToBeStringed = encodeSlashes(queryObjectToBeStringed);
       var queryObjectString = $rison.stringify(queryObjectToBeStringed);

--- a/client/assets/js/services/URLService.js
+++ b/client/assets/js/services/URLService.js
@@ -13,30 +13,34 @@
     wt: 'json'
   };
 
-  function URLService($log, $rison, $state, $location, BLANK_QUERY,
+  function URLService(ConfigService, $log, $rison, $injector, $location,
     QUERY_PARAM) {
     'ngInject';
     return {
-      setQuery: setQuery,
+      setQueryToURLAndGo: setQueryToURLAndGo,
+      convertQueryToStateObject: convertQueryToStateObject,
       getQueryFromUrl: getQueryFromUrl
     };
 
     //////////
 
     /**
-     * Sets the query object that will be updated
-     * on the URL bar and get passed
-     * on to QueryService
-     * for a search
+     * Sets the URL bar
      * @param {object} queryObject The query object
      */
-    function setQuery(queryObject) {
+    function convertQueryToStateObject(queryObject) {
       var queryObjectToBeStringed = _.clone(queryObject,true);
       //Only need the slashes to get encoded, so that app state doesn't change
       queryObjectToBeStringed = encodeSlashes(queryObjectToBeStringed);
       var queryObjectString = $rison.stringify(queryObjectToBeStringed);
       var newStateObject = {};
       newStateObject[QUERY_PARAM] = queryObjectString;
+      return newStateObject;
+    }
+
+    function setQueryToURLAndGo(queryObject) {
+      var newStateObject = convertQueryToStateObject(queryObject);
+      var $state = $injector.get('$state');
       // Adding reloadOnSearch:false for now fixes the double reload bug SU-60
       // @see http://stackoverflow.com/a/22863315
       $state.go('home', newStateObject, {notify: false, reloadOnSearch: false});
@@ -49,11 +53,11 @@
       var queryString = $location.search()[QUERY_PARAM];
       var queryObject;
       try{
-        queryObject = queryString ? $rison.parse(decodeURIComponent(queryString)):BLANK_QUERY;
+        queryObject = queryString ? $rison.parse(decodeURIComponent(queryString)):ConfigService.config.default_query;
       }
       catch(e){
         $log.error('Cannot parse query URL');
-        queryObject = BLANK_QUERY;
+        queryObject = ConfigService.config.default_query;
       }
       var temp = convertTreeArrays(queryObject);
       return temp;

--- a/client/templates/login.html
+++ b/client/templates/login.html
@@ -1,6 +1,6 @@
 ---
 name: login
-url: /login
+url: /login?query
 controller: LoginController as vm
 ---
 <div class="grid-frame vertical">

--- a/tests/assets/js/services/URLServiceTest.js
+++ b/tests/assets/js/services/URLServiceTest.js
@@ -32,7 +32,7 @@ ngDescribe({
     });
 
     it('setQuery should make the right calls as well', function(){
-      deps.URLService.setQuery({});
+      deps.QueryService.setQuery({});
       expect(deps.$state.go).toHaveBeenCalledWith('home', {query:'(q:\'*\',start:0,wt:json)'}, {notify: false, reloadOnSearch: false});
       expect(deps.$rison.stringify).toHaveBeenCalledWith({
         q:'*',


### PR DESCRIPTION
# Tl;dr
Keeps your query even when redirecting from a url

# Details
- [x] fix auth interceptor so it will pass the data through
- [x] get typeahead to recognize the url when it is passed through
- [x] allow users to specify a default query

# How to verify
1. Copy a working url
2. Logout
3. Paste the working url
4. login

expected result:
should redirect to right query and typeahead should have the right query value.

