### PR TITLE
TI-242: Support authentication via SAML

### DIFF
--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -38,6 +38,9 @@ appConfig = { //eslint-disable-line
   /**
    * The name of the realm to connect with
    *   default: 'native'
+   *
+   * SAML auth is also supported via config as
+   *   { type: 'saml', name: 'saml_realm_name' }
    */
   connection_realm: 'native',
 

--- a/FUSION_CONFIG.sample.js
+++ b/FUSION_CONFIG.sample.js
@@ -36,13 +36,16 @@ appConfig = { //eslint-disable-line
   // },
 
   /**
-   * The name of the realm to connect with
-   *   default: 'native'
-   *
-   * SAML auth is also supported via config as
-   *   { type: 'saml', name: 'saml_realm_name' }
+   * The name of the realm to connect with, and the authentication type if SAML is used.
+   * The default is:
+   * connection_realm: { name: 'native' }
    */
-  connection_realm: 'native',
+  connection_realm: {
+    name: 'native',
+
+    // If you are using SAML authentication, uncomment the following line:
+    // type: 'saml'
+  },
 
   /**
    * Anonymous access

--- a/client/assets/components/login/_login.scss
+++ b/client/assets/components/login/_login.scss
@@ -1,0 +1,14 @@
+.login-form:not(.has-input-fields) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 100px;
+
+  label {
+    display: none;
+  }
+
+  .button {
+    width: 100px;
+  }
+}

--- a/client/assets/components/login/login.html
+++ b/client/assets/components/login/login.html
@@ -1,4 +1,6 @@
-<form class="content-block" ng-submit="vm.submit()">
+<form class="content-block login-form" ng-submit="vm.submit()" ng-class="{ 'has-input-fields': !vm.useSamlAuth }">
+  <h1>{{ vm.useSamlAuth ? 'Click below to log in' : 'Please login' }}</h1>
+
   <label>
     Username
     <input type="text" ng-model="vm.username" />

--- a/client/assets/components/login/login.js
+++ b/client/assets/components/login/login.js
@@ -30,6 +30,14 @@
 
     vm.submit = submit;
 
+    init();
+
+    function init() {
+      if (AuthService.hasSamlRealm()) {
+        AuthService.getSession().catch(AuthService.authBySaml);
+      }
+    }
+
     function submit() {
       vm.error = null;
       vm.submitting = true;

--- a/client/assets/components/login/login.js
+++ b/client/assets/components/login/login.js
@@ -27,18 +27,19 @@
     vm.password = '';
     vm.error = null;
     vm.submitting = false;
+    vm.useSamlAuth = AuthService.hasSamlRealm();
 
     vm.submit = submit;
 
-    init();
-
-    function init() {
-      if (AuthService.hasSamlRealm()) {
-        AuthService.getSession().catch(AuthService.authBySaml);
+    function submit() {
+      if (vm.useSamlAuth) {
+        AuthService.authBySaml();
+      } else {
+        createSession();
       }
     }
 
-    function submit() {
+    function createSession() {
       vm.error = null;
       vm.submitting = true;
       AuthService
@@ -58,7 +59,6 @@
         vm.submitting = false;
         vm.error = err;
       }
-
     }
   }
 })();

--- a/client/assets/js/services/AuthInterceptor.js
+++ b/client/assets/js/services/AuthInterceptor.js
@@ -89,15 +89,22 @@
 
       tryingAnon = true;
       var def = $q.defer();
-      AuthService.createSession(ConfigService.config.anonymous_access.username, ConfigService.config.anonymous_access.password)
-        .then(function(resp){
-          tryingAnon = false;
-          def.reject(resp);
-        }).catch(function(error){
-          tryingAnon = false;
-          def.reject(error);
-        });
-      return def.promise;
+      let hasSamlRealm = AuthService.hasSamlRealm();
+
+      if (hasSamlRealm) {
+        AuthService.authBySaml();
+      } else {
+        AuthService.createSession(ConfigService.config.anonymous_access.username, ConfigService.config.anonymous_access.password)
+          .then(function(resp){
+            tryingAnon = false;
+            def.reject(resp);
+          }).catch(function(error){
+            tryingAnon = false;
+            def.reject(error);
+          });
+      }
+
+      return hasSamlRealm ? $q.when(true) : def.promise;
     }
 
     /**

--- a/client/assets/js/services/AuthInterceptor.js
+++ b/client/assets/js/services/AuthInterceptor.js
@@ -89,22 +89,15 @@
 
       tryingAnon = true;
       var def = $q.defer();
-      let hasSamlRealm = AuthService.hasSamlRealm();
-
-      if (hasSamlRealm) {
-        AuthService.authBySaml();
-      } else {
-        AuthService.createSession(ConfigService.config.anonymous_access.username, ConfigService.config.anonymous_access.password)
-          .then(function(resp){
-            tryingAnon = false;
-            def.reject(resp);
-          }).catch(function(error){
-            tryingAnon = false;
-            def.reject(error);
-          });
-      }
-
-      return hasSamlRealm ? $q.when(true) : def.promise;
+      AuthService.createSession(ConfigService.config.anonymous_access.username, ConfigService.config.anonymous_access.password)
+        .then(function(resp){
+          tryingAnon = false;
+          def.reject(resp);
+        }).catch(function(error){
+          tryingAnon = false;
+          def.reject(error);
+        });
+      return def.promise;
     }
 
     /**

--- a/client/assets/js/services/AuthService.js
+++ b/client/assets/js/services/AuthService.js
@@ -27,7 +27,7 @@
     }
 
     function authBySaml() {
-      $window.location = `api/saml/${realmName}`; 
+      $window.location = 'api/saml/' + realmName; 
     }
 
     function createSession(username, password) {

--- a/client/assets/js/services/AuthService.js
+++ b/client/assets/js/services/AuthService.js
@@ -7,19 +7,28 @@
     ])
     .factory('AuthService', AuthService);
 
-  function AuthService($q, $log, $http, $rootScope, ApiBase, ConfigService) {
+  function AuthService($q, $log, $http, $rootScope, $window, ApiBase, ConfigService) {
     'ngInject';
     var config = ConfigService.config;
-    var realmName = config.connection_realm;
+    var realmName = _.get(config.connection_realm, 'name') || config.connection_realm;
 
     return {
       createSession: createSession,
       getSession: getSession,
-      destroySession: destroySession
+      destroySession: destroySession,
+      hasSamlRealm: hasSamlRealm,
+      authBySaml: authBySaml
     };
 
     //////////////
 
+    function hasSamlRealm() {
+      return _.get(config.connection_realm, 'type') === 'saml';
+    }
+
+    function authBySaml() {
+      $window.location = `api/saml/${realmName}`; 
+    }
 
     function createSession(username, password) {
       var deferred = $q.defer();

--- a/client/templates/login.html
+++ b/client/templates/login.html
@@ -20,7 +20,6 @@ controller: LoginController as vm
     <!-- Main Content Frame -->
     <div class="grid-container">
       <main class="grid-content">
-        <h1>Please login</h1>
         <login></login>
       </main>
     </div>


### PR DESCRIPTION
Support SAML authentication if `connection_realm` is configured as 
```{ type: 'saml', name: 'saml_realm_name' }```

If SAML realm is available, directly auth to SAML via fusion with url `api/saml/saml_realm_name` for all routes (/search, /login, etc...)

PS: Currently there might be a potential issue that it will be redirected to fusion if the realm has redirect url pointing to fusion UI. A possible workaround would be having another SAML realm with redirect url pointing to view. (side effect will be that the realm will also be displayed in the login realm dropdown in fusion UI)