### PR TITLE
JavaScript Initializations are Not Hoisted

### DIFF
--- a/client/assets/js/services/URLService.js
+++ b/client/assets/js/services/URLService.js
@@ -1,17 +1,17 @@
 (function () {
   'use strict';
 
-  angular
-    .module('lucidworksView.services.url', ['rison'])
-    .constant('BLANK_QUERY', blankQuery)
-    .constant('QUERY_PARAM', 'query')
-    .factory('URLService', URLService);
-
   var blankQuery = {
     q: '*',
     start: 0,
     wt: 'json'
   };
+
+  angular
+    .module('lucidworksView.services.url', ['rison'])
+    .constant('BLANK_QUERY', blankQuery)
+    .constant('QUERY_PARAM', 'query')
+    .factory('URLService', URLService);
 
   function URLService(ConfigService, $log, $rison, $injector, $location,
     QUERY_PARAM) {


### PR DESCRIPTION
JavaScript Initializations are Not Hoisted, so blankquery seems to be used before init'd.
Sorry, this change is not tested. Please ignore it at will. 
cheers -- Rick